### PR TITLE
fix for deprecated easy-install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ USER root
 # Install base packages
 RUN apt-get update -y && \
     apt-get install apt-transport-https curl python-dev python-setuptools gcc make libssl-dev jq -y && \
-    easy_install pip \
+    apt-get install python-pip -y \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 # Install Python packages


### PR DESCRIPTION
installing pip by apt-get instead of easy-install. 

> Warning
> Easy Install is deprecated. Do not use it. Instead use pip. If you think you need Easy Install, please reach out to the PyPA team (a ticket to pip or setuptools is fine), describing your use-case.
